### PR TITLE
remove cache params, fails to load due to cors errors

### DIFF
--- a/src/bhatkhande_editor/events.cljs
+++ b/src/bhatkhande_editor/events.cljs
@@ -849,11 +849,14 @@
    (println "getting comp from " urlparams)
    (let [tr (t/reader :json)]
      (-> (js/fetch
-          (db/get-bandish-url (str path "/" id))
-          (clj->js {:cache "no-store"
+          (str (db/get-bandish-url (str path "/" id))
+               "?_=" (.getTime (js/Date.)))
+          ;;setting cache no-store fails to load from the URL, it hits a CORS error,
+          ;;hence removing.
+          (clj->js {;;:cache "no-store"
                     :method "get"
-                    :headers {"pragma" "no-cache"
-                              "cache-control" "no-cache"}})
+                    ;;:headers {"pragma" "no-cache" "cache-control" "no-cache"}
+                    })
           )
          (.then (fn[i] (.text i)))
          (.then (fn[i]


### PR DESCRIPTION
Setting cache params causes CORS errors, hence removing it