### PR TITLE
don't cache JS files as the single-bhaag format is loaded and causes …

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
 	"name": "bandish-editor",
 	"scripts": {
 		"ancient": "clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}' -m antq.core",
-		"watch": "npx workbox injectManifest workbox-config.js && npx shadow-cljs watch app browser-test karma-test",
+		"watch": "npx shadow-cljs watch app browser-test karma-test",
 		"test": "npx shadow-cljs compile test && node out/node-tests.js",
-		"release": "npx workbox injectManifest workbox-config.js && npx shadow-cljs release app && clojure -X bhatkhande-editor.sitemap/spit-sitemap",
+		"release": "npx shadow-cljs release app && npx workbox injectManifest workbox-config.js && clojure -X bhatkhande-editor.sitemap/spit-sitemap",
 		"build-report": "npx shadow-cljs run shadow.cljs.build-report app target/build-report.html",
 		"dev": "npx shadow-cljs watch app",
 		"test:puppeteer": "replay puppeteer_recordings",

--- a/sw-src.js
+++ b/sw-src.js
@@ -4,7 +4,7 @@ importScripts(
 
 workbox.precaching.precacheAndRoute(self.__WB_MANIFEST);
 
-workbox.routing.registerRoute(/\.(?:png|gif|jpg|jpeg|woff|woff2|eot|ttf|svg)$/, new workbox.strategies.CacheFirst());
+workbox.routing.registerRoute(/\.(?:png|gif|jpg|jpeg|woff|woff2|eot|ttf|svg|mp3)$/, new workbox.strategies.CacheFirst());
 
 workbox.routing.registerRoute(
   ({url}) => url.pathname.startsWith('/view/'),
@@ -12,6 +12,11 @@ workbox.routing.registerRoute(
 );
 
 workbox.routing.registerRoute(
-  /\.(?:js|html|css)$/,
+  ({url}) => url.pathname.startsWith('/js/compiled/'),
+  new workbox.strategies.NetworkFirst()
+);
+
+workbox.routing.registerRoute(
+  /\.(?:html|css)$/,
   new workbox.strategies.StaleWhileRevalidate()
 );


### PR DESCRIPTION
…an empty file to be saved.

In the workbox config, load the JS files with a networkFirst strategy. 

partial solution to #193 
